### PR TITLE
Removes the annoying banner from the output

### DIFF
--- a/sslScrape.py
+++ b/sslScrape.py
@@ -120,7 +120,8 @@ def callback(conn, cert, errno, depth, result):
     return True
 
 if __name__ == "__main__":  
-    banner()
+    if len(sys.argv) < 2:
+        banner()
     try:
         cidr =  sys.argv[1:][0]
     except:


### PR DESCRIPTION
This removes the unneccessary banner from the output which pollutes the data from a large file when scanning massive CIDRs